### PR TITLE
Modified to be able to recursively parse Front Matter

### DIFF
--- a/auto-translater.py
+++ b/auto-translater.py
@@ -185,6 +185,11 @@ def translate_front_matter(front_matter, lang):
                     processed_value = recursive_translate(v, lang)
                 translated_dict[k] = processed_value
             return translated_dict
+        elif isinstance(value, list): #处理数组
+            translated_list = []
+            for item in value:
+                translated_list.append(recursive_translate(item, lang))
+            return translated_list
         else:
             return value
 

--- a/auto-translater.py
+++ b/auto-translater.py
@@ -175,16 +175,20 @@ def translate_text(text, lang, type):
 
 # Front Matter 处理规则
 def translate_front_matter(front_matter, lang):
-    translated_front_matter = {}
-    for key, value in front_matter.items():
-        if key in front_matter_translation_rules:
-            processed_value = front_matter_translation_rules[key](value, lang)
+    def recursive_translate(value, lang):
+        if isinstance(value, dict):
+            translated_dict = {}
+            for k, v in value.items():
+                if k in front_matter_translation_rules:
+                    processed_value = front_matter_translation_rules[k](v, lang)
+                else:
+                    processed_value = recursive_translate(v, lang)
+                translated_dict[k] = processed_value
+            return translated_dict
         else:
-            # 如果在规则列表内，则不做任何翻译或替换操作
-            processed_value = value
-        translated_front_matter[key] = processed_value
-        # print(key, ":", processed_value)
-    return translated_front_matter
+            return value
+
+    return recursive_translate(front_matter, lang)
 
 # 定义文章拆分函数
 def split_text(text, max_length):


### PR DESCRIPTION
注意：我没有在此项目运行测试，但是我是基于自己的项目进行测试。

本次的修改是针对YAML的递归处理。

原文
```md
---
layout: home

hero:
  name: "xxx"
  text: "在你的本地设备上部署自己的 .dweb 域名"
  tagline: 我们协助鼓励开发者打造开放 Web应用，通过开放标准，应用之间可以实现互操作，这将开启一种全新的互联网体验，并为世界带来无尽的可能性。
  image:
    src: /logo.svg
    alt: dweb
---
```
翻译
```md
---
layout: home
hero:
  name: xxx
  text: Instale su propio nombre de dominio `.dweb` en su dispositivo local.
  tagline: Nosotros ayudamos a alentar a los desarrolladores a construir aplicaciones
    web abiertas, logrando la interoperabilidad entre ellas mediante estándares abiertos.
    Esto abrirá una experiencia de internet completamente nueva y traerá sin fin posibilidades
    para el mundo.
  image:
    src: /logo.svg
    alt: dweb
---
```

并且因为我没有openAI key 我使用的是[ollama](https://github.com/ollama/ollama-python) 运行`llama3`于本地翻译。
